### PR TITLE
fixed a bug when saving ply files into hdfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A library for reading and writing Lidar point cloud collections in PLY, LAS and 
 
 ## Requirements
 
-This Spark package is for Spark 1.5+.
+This Spark package is for Spark 1.6.1
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.10.6"
 
 spName := "IGNF/spark-iqmulus"
 
-sparkVersion := "1.6.0"
+sparkVersion := "1.6.1"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/src/main/scala/fr/ign/spark/iqmulus/ply/PlyRelation.scala
+++ b/src/main/scala/fr/ign/spark/iqmulus/ply/PlyRelation.scala
@@ -48,7 +48,8 @@ class PlyOutputCommitter(
 
       val header = {
         // read all headers
-        val headers = paths.flatMap(path => Try(PlyHeader.read(path)) match {
+        // val headers = paths.flatMap(path => Try(PlyHeader.read(path)) match { // doesn't work for URI like hdfs://
+        val headers = paths.flatMap(path => Try(PlyHeader.read(path.toString, fs.open(path))) match {
           case Success(h) => Some(h)
           case Failure(e) => logWarning(s"Skipping $path : e.getMessage"); None
         })


### PR DESCRIPTION
When saving ply files into hdfs with URI like hdfs://, the following line will crash the program

`val headers = paths.flatMap(path => Try(PlyHeader.read(path)) match {`

The right code should be 
`val headers = paths.flatMap(path => Try(PlyHeader.read(path.toString, fs.open(path))) match {`
