### PR TITLE
Should not close file system inside of map call.

### DIFF
--- a/src/main/scala/fr/ign/spark/iqmulus/las/LasHeader.scala
+++ b/src/main/scala/fr/ign/spark/iqmulus/las/LasHeader.scala
@@ -198,7 +198,6 @@ case class LasHeader(
       }
     } finally {
       fileInputStream.close
-      fs.close
     }
     val res = for ((r, bytes) <- vlrWithBytes; i <- 0 until r.recordLength.toInt by 192)
       yield new ExtraBytes(bytes.slice(i, i + 192))


### PR DESCRIPTION
Since the file system handler is shared by other map threads.